### PR TITLE
Upgrade GoReleaser action to support v2 config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
           go-version: stable
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Upgrades the `goreleaser/goreleaser-action` from `v5` to `v6`
- Sets the version constraint to `'~> v2'` to ensure compatibility with GoReleaser v2
- Fixes the release workflow to support the existing `.goreleaser.yaml` version 2 configuration

## Test plan
- [x] Verify the release workflow runs successfully with the updated action
- [ ] Confirm a new release can be created without version conflicts

💖 Generated with Crush